### PR TITLE
#6 Jacoco integration and Code Coverage using Codacy

### DIFF
--- a/.github/workflows/back-end.yml
+++ b/.github/workflows/back-end.yml
@@ -19,6 +19,6 @@ jobs:
 
       - name: Upload Coverage Raport from Jacoco to Codacy
         run: |
-        mvn jacoco:report
-        cd target && cd site && cd jacoco
-        bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r jacoco.xml
+          mvn jacoco:report
+          cd target && cd site && cd jacoco
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r jacoco.xml

--- a/.github/workflows/back-end.yml
+++ b/.github/workflows/back-end.yml
@@ -16,3 +16,9 @@ jobs:
 
       - name: Test with Maven
         run: mvn test
+
+      - name: Upload Coverage Raport from Jacoco to Codacy
+        run: |
+        mvn jacoco:report
+        cd target && cd site && cd jacoco
+        bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r jacoco.xml

--- a/.github/workflows/back-end.yml
+++ b/.github/workflows/back-end.yml
@@ -19,6 +19,6 @@ jobs:
 
       - name: Upload Coverage Raport from Jacoco to Codacy
         run: |
-          mvn jacoco:reports
+          mvn jacoco:report
           cd target && cd site && cd jacoco
           bash <(curl -Ls https://coverage.codacy.com/get.sh -H 'project-token: e95ff09eb425437da36048afebefe7d5') report -r jacoco.xml

--- a/.github/workflows/back-end.yml
+++ b/.github/workflows/back-end.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Upload Coverage Raport from Jacoco to Codacy
         env:
-          CODACY_PROJECT_TOKEN: e95ff09eb425437da36048afebefe7d5
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
         run: |
           mvn jacoco:report
           cd target && cd site && cd jacoco

--- a/.github/workflows/back-end.yml
+++ b/.github/workflows/back-end.yml
@@ -18,7 +18,9 @@ jobs:
         run: mvn test
 
       - name: Upload Coverage Raport from Jacoco to Codacy
+        env:
+          CODACY_PROJECT_TOKEN: e95ff09eb425437da36048afebefe7d5
         run: |
           mvn jacoco:report
           cd target && cd site && cd jacoco
-          bash <(curl -Ls https://coverage.codacy.com/get.sh -H 'project-token: e95ff09eb425437da36048afebefe7d5') report -r jacoco.xml
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r jacoco.xml

--- a/.github/workflows/back-end.yml
+++ b/.github/workflows/back-end.yml
@@ -19,6 +19,6 @@ jobs:
 
       - name: Upload Coverage Raport from Jacoco to Codacy
         run: |
-          mvn jacoco:report
+          mvn jacoco:reports
           cd target && cd site && cd jacoco
-          bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r jacoco.xml
+          bash <(curl -Ls https://coverage.codacy.com/get.sh -H 'project-token: e95ff09eb425437da36048afebefe7d5') report -r jacoco.xml

--- a/pom.xml
+++ b/pom.xml
@@ -94,14 +94,13 @@
                 <version>0.8.7</version>
                 <executions>
                     <execution>
-                        <id>prepare-agent</id>
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
                     </execution>
                     <execution>
                         <id>report</id>
-                        <phase>test</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>


### PR DESCRIPTION
#6 Jacoco Integration to pom.xml
Update workflow to create jacoco report and upload result to Codacy in order to have code coverage for tests.