### PR TITLE
Ignore Autoconfigure for datasource

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.datasource.driverClassName=org.postgresql.Driver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 # Flyway
 spring.flyway.url=jdbc:postgresql://postgres_db:5432/postgres
-spring.flyway.user=postgres
+spring.flyway.user=postgress
 spring.flyway.password=root
 spring.flyway.locations=classpath:db/migrations
 spring.flyway.sqlMigrationPrefix=V

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,15 +1,3 @@
-spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
-spring.datasource.username=postgres
-spring.datasource.password=root
-spring.datasource.driverClassName=org.postgresql.Driver
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
-# Flyway
-spring.flyway.url=jdbc:postgresql://localhost:5432/postgres
-spring.flyway.user=postgres
-spring.flyway.password=root
-spring.flyway.locations=classpath:db/migrations
-spring.flyway.sqlMigrationPrefix=V
-spring.flyway.sqlMigrationSeparator=__
-spring.flyway.sql-migration-suffixes=.sql
-spring.flyway.validateOnMigrate=true
-spring.flyway.enabled=false
+spring.sql.init.mode=never
+
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration,org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration,org.springframework.boot.autoconfigure.data.web.SpringDataWebAutoConfiguration


### PR DESCRIPTION
#8 Ignore autoconfigure for datasource in order to run workflow faster.